### PR TITLE
Parse markdown table lists

### DIFF
--- a/lists/plugins.md
+++ b/lists/plugins.md
@@ -593,9 +593,7 @@
 | [Day and Night](https://github.com/CyberT17/obsidian-day-and-night) | Automatically toggle themes between day theme and night theme on a set time schedule. |
 | [TikZJax](https://github.com/artisticat1/obsidian-tikzjax) | Render LaTeX and TikZ diagrams in your notes. |
 | [Todoist completed tasks](https://github.com/Ledaryy/obsidian-todoist-completed-tasks) | Add completed Todoist tasks to your notes. |
-| [Quick snippets and navigation](https://github.com/ieviev/obsidian-keyboard-shortcuts) | Keyboard navigation up/down for headings
-- Configurable default code block and callout
-- Copy code block via keyboard shortcut. |
+| [Quick snippets and navigation](https://github.com/ieviev/obsidian-keyboard-shortcuts) | Keyboard navigation up/down for headings<br />- Configurable default code block and callout<br />- Copy code block via keyboard shortcut. |
 | [Google Calendar](https://github.com/YukiGasai/obsidian-google-calendar) | Interact with your Google Calendar. |
 | [Copy Search URL](https://github.com/czottmann/obsidian-copy-search-url) | Add a button to the search view to copy the search URL. |
 | [Super Simple Time Tracker](https://github.com/Ellpeck/ObsidianSimpleTimeTracker) | Multi-purpose time trackers for your notes. |

--- a/src/markdownTable.test.ts
+++ b/src/markdownTable.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createMarkdownTable } from "./markdownTable";
+import { createMarkdownTable, parseMarkdownTable } from "./markdownTable";
 
 describe("createMarkdownTable", () => {
   test("renders well-formed markdown with escaped characters", () => {
@@ -17,5 +17,30 @@ describe("createMarkdownTable", () => {
     const table = createMarkdownTable(["A", "B", "C"], [["x"]]);
 
     expect(table.endsWith("| x |   |   |")).toBe(true);
+  });
+});
+
+describe("parseMarkdownTable", () => {
+  test("handles rows that span multiple lines", () => {
+    const markdown = [
+      "| 📁 Name | ✨ Description |",
+      "| --- | --- |",
+      "| [Quick snippets and navigation](https://github.com/ieviev/obsidian-keyboard-shortcuts) | Keyboard navigation up/down for headings",
+      "- Configurable default code block and callout",
+      "- Copy code block via keyboard shortcut. |",
+    ].join("\n");
+
+    const parsed = parseMarkdownTable(markdown);
+
+    expect(parsed.headers).toEqual(["📁 Name", "✨ Description"]);
+    expect(parsed.rows).toHaveLength(1);
+    expect(parsed.rows[0][1]).toBe(
+      "Keyboard navigation up/down for headings\n- Configurable default code block and callout\n- Copy code block via keyboard shortcut.",
+    );
+
+    const regenerated = createMarkdownTable(parsed.headers, parsed.rows);
+
+    expect(regenerated).toContain("<br />- Configurable default code block");
+    expect(regenerated.includes("\n- Configurable")).toBe(false);
   });
 });

--- a/src/markdownTable.ts
+++ b/src/markdownTable.ts
@@ -18,6 +18,95 @@ function normalizeRow(row: string[], columnCount: number): string[] {
   return normalized;
 }
 
+export type ParsedMarkdownTable = {
+  headers: string[];
+  rows: string[][];
+};
+
+function splitRowIntoCells(row: string): string[] {
+  const trimmed = row.trim();
+
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) {
+    throw new Error(`Invalid table row: ${row}`);
+  }
+
+  const content = trimmed.slice(1, -1);
+  const cells: string[] = [];
+  let buffer = "";
+  let index = 0;
+
+  while (index < content.length) {
+    const char = content[index];
+
+    if (char === "\\") {
+      const nextChar = content[index + 1];
+
+      if (nextChar === "|") {
+        buffer += "|";
+        index += 2;
+        continue;
+      }
+
+      buffer += "\\";
+      index += 1;
+      continue;
+    }
+
+    if (char === "|") {
+      cells.push(buffer.trim());
+      buffer = "";
+      index += 1;
+      continue;
+    }
+
+    buffer += char;
+    index += 1;
+  }
+
+  cells.push(buffer.trim());
+
+  return cells;
+}
+
+function isDividerCell(value: string): boolean {
+  return /^:?-{3,}:?$/.test(value.trim());
+}
+
+function collectTableRows(markdown: string): string[] {
+  const lines = markdown.split(/\r?\n/);
+  const rows: string[] = [];
+  let buffer: string[] = [];
+
+  const pushBuffer = (): void => {
+    if (buffer.length > 0) {
+      rows.push(buffer.join("\n"));
+      buffer = [];
+    }
+  };
+
+  for (const line of lines) {
+    if (buffer.length === 0) {
+      if (line.trim().length === 0) {
+        continue;
+      }
+
+      if (!line.trimStart().startsWith("|")) {
+        continue;
+      }
+    }
+
+    buffer.push(line);
+
+    if (line.trimEnd().endsWith("|")) {
+      pushBuffer();
+    }
+  }
+
+  pushBuffer();
+
+  return rows;
+}
+
 export function createMarkdownTable(
   headers: string[],
   rows: string[][],
@@ -34,4 +123,32 @@ export function createMarkdownTable(
   const rowLines = normalizedRows.map((row) => `| ${row.join(" | ")} |`);
 
   return [headerLine, dividerLine, ...rowLines].join("\n");
+}
+
+export function parseMarkdownTable(markdown: string): ParsedMarkdownTable {
+  const rows = collectTableRows(markdown);
+
+  if (rows.length < 2) {
+    throw new Error("Markdown table must include headers and divider row");
+  }
+
+  const [headerRow, dividerRow, ...dataRows] = rows;
+
+  if (!headerRow || !dividerRow) {
+    throw new Error("Markdown table must include headers and divider row");
+  }
+
+  const headers = splitRowIntoCells(headerRow);
+  const dividerCells = splitRowIntoCells(dividerRow);
+
+  if (
+    dividerCells.length !== headers.length ||
+    !dividerCells.every(isDividerCell)
+  ) {
+    throw new Error("Invalid markdown table divider row");
+  }
+
+  const parsedRows = dataRows.map((row) => splitRowIntoCells(row));
+
+  return { headers, rows: parsedRows };
 }


### PR DESCRIPTION
Adds markdown table parsing to support multi-line cells and fixes a broken table in `lists/plugins.md`.

The new parsing logic correctly interprets multi-line content within table cells, and the `createMarkdownTable` function now converts these internal newlines to `<br />` tags for proper rendering, preventing table layout issues caused by lists or other multi-line content.

---
<a href="https://cursor.com/background-agent?bcId=bc-db31c3bb-21f3-4891-ad4a-2c576c4abdc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db31c3bb-21f3-4891-ad4a-2c576c4abdc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

