### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/src/markdownTable.ts
+++ b/src/markdownTable.ts
@@ -1,5 +1,6 @@
 function sanitizeCell(value: string): string {
   const cleaned = value
+    .replace(/\\/g, "\\\\")
     .replace(/\|/g, "\\|")
     .replace(/\r?\n/g, "<br />")
     .trim();


### PR DESCRIPTION
Potential fix for [https://github.com/konhi/obsidian-community-list/security/code-scanning/2](https://github.com/konhi/obsidian-community-list/security/code-scanning/2)

To fix the issue, we need to ensure that all backslash (`\`) characters in a cell value are escaped, before escaping pipe characters and applying other replacements. This should be done by replacing all occurrences of `\` with `\\`, using a global regular expression (`/\\/g`) in the first step of the sanitization process to avoid double-escaping any later-inserted backslash characters. Thus, the sequence in the `sanitizeCell` function should first escape backslashes, then escape pipes, and finally apply the newline replacement and trim. Only the contents of the `sanitizeCell` function (lines 2–8) should change; no imports or extra dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
