### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/konhi/obsidian-community-list/security/code-scanning/1](https://github.com/konhi/obsidian-community-list/security/code-scanning/1)

To address the issue, we should add a `permissions` block that grants only the minimum required permissions to the workflow. For this workflow, most steps require only `contents: read`, except for the scheduled run step that pushes changes and thus needs `contents: write`. The simplest secure solution is to place a `permissions:` key at the job level (under `build:`), granting `contents: write` (the minimum required for pushing back to the repo) for that job. Optionally, for further granularity, we could define a second job or use a step-specific token, but GitHub does not yet support per-step permissions, so per-job is best. The permissions block should appear directly under the job (`build:`) and before `runs-on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
