### PR TITLE
Update community urls

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -7,9 +7,9 @@ const OUTPUT_DIRECTORY = "lists";
 const URLS = {
   github: "https://github.com",
   themes:
-    "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-css-themes.json",
+    "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/refs/heads/master/community-css-themes.json",
   plugins:
-    "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugins.json",
+    "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/refs/heads/master/community-plugins.json",
 };
 
 export type PluginRecord = {


### PR DESCRIPTION
Update community theme and plugin fetch URLs to use `refs/heads/master` as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-228a7418-78de-4395-80bf-45d704e162a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-228a7418-78de-4395-80bf-45d704e162a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

